### PR TITLE
'=' should be used for number comparison

### DIFF
--- a/git-ps1-mode.el
+++ b/git-ps1-mode.el
@@ -136,11 +136,11 @@ String \"%s\" will be replaced with the output of \"__git_ps1 %s\".")
        (with-temp-buffer
          (insert ". " f "; "
                  "__git_ps1 %s;")
-         (eq 0 (shell-command-on-region (point-min)
-                                        (point-max)
-                                        "bash -s"
-                                        nil
-                                        t)))
+         (= 0 (shell-command-on-region (point-min)
+                                       (point-max)
+                                       "bash -s"
+                                       nil
+                                       t)))
        f))
 
 (defun git-ps1-mode-find-ps1-file (&optional list)


### PR DESCRIPTION
Emacs document says 

> To test numbers for numerical equality, you should normally use `=`, not `eq`.

http://www.gnu.org/software/emacs/manual/html_node/elisp/Comparison-of-Numbers.html
